### PR TITLE
Add support for custom icons by id in blender

### DIFF
--- a/dev/unimenu_samples/blender_custom_icon.py
+++ b/dev/unimenu_samples/blender_custom_icon.py
@@ -1,0 +1,13 @@
+import unimenu
+import pyblish_lite
+import pathlib
+
+
+icon_path = pathlib.Path(pyblish_lite.__file__).parent / "img" / "logo-extrasmall.png"
+menu_node = unimenu.Node(
+    label="pyblish lite",
+    command="import pyblish_lite;pyblish_lite.show()",
+    tooltip="Open Pyblish Lite",
+    icon=str(icon_path),
+)
+menu_node.setup()

--- a/unimenu/apps/blender.py
+++ b/unimenu/apps/blender.py
@@ -13,6 +13,11 @@ from typing import Union, Callable
 from unimenu.apps._abstract import MenuNodeAbstract
 import unimenu.apps
 
+
+preview_collections = {}  # store custom icons here to prevent blender warnings
+# todo cleanup on teardown / unload with bpy.utils.previews.remove(preview_collection)
+
+
 def unique_operator_name(name) -> str:
     """ensure unique name for blender operators, adds _number to the end if name not unique"""
     unique_counter = 1  # start count from 2
@@ -33,14 +38,15 @@ def create_custom_icon(path, name: str = None):
     """
     name = name or "icon_name"
 
+    preview_collection = preview_collections.get(path)
+    if preview_collection:
+        return preview_collection[name].icon_id
+
     preview_collection = bpy.utils.previews.new()
+    preview_collections[path] = preview_collection
     icon = preview_collection.load(name=name, path=str(path), path_type='IMAGE')
-
     icon_ID = icon.icon_id
-    # icon = preview_collection["icon_name"]  # icon can be loaded by name
 
-    # bpy.utils.previews.remove(preview_collection)  # delete preview to avoid warning
-    # deleting this also deletes the icon, todo how to handle this better?
     return icon_ID
 
 

--- a/unimenu/apps/blender.py
+++ b/unimenu/apps/blender.py
@@ -70,7 +70,11 @@ def operator_wrapper(
     def menu_draw(self, context):  # self is the parent menu
         # todo check if icon exists, if not use NONE, for now dirty try except hack
         try:
-            self.layout.operator(id_name, icon=icon_name)
+            if isinstance(icon_name, int):
+                # if the icon is a number it might be a custom icon
+                self.layout.operator(id_name, icon_value=icon_name)
+            else:
+                self.layout.operator(id_name, icon=icon_name)
         except TypeError:  # icon not found:
             self.layout.operator(id_name, icon="NONE")
 

--- a/unimenu/apps/blender.py
+++ b/unimenu/apps/blender.py
@@ -66,31 +66,32 @@ def operator_wrapper(
     bpy.utils.register_class(OperatorWrapper)
 
     # ensure None was not accidentally passed
-    icon_name = icon_name or "NONE"
+    icon_value = icon_name or "NONE"
 
     # add to menu
     def menu_draw(self, context):  # self is the parent menu
+        _icon_ID = None
+        _icon_name = None
 
-        icon_ID = None
-        icon_name = None
+        if isinstance(icon_value, int):  # use icon ID for custom icons
+            logging.debug(f"icon_name is int: {icon_value}")
+            _icon_ID = icon_value
 
-        if isinstance(icon_name, int):  # use icon ID for custom icons
-            logging.debug(f"icon_name is int: {icon_name}")
-            icon_ID = icon_name
+        elif isinstance(icon_value, str):  # if str, can be default icon name, or a string path
+            logging.debug(f"icon_name is str: {icon_value}")
+            _icon_name=icon_value
 
-        elif isinstance(icon_name, str):  # if str, can be default icon name, or a string path
-            logging.debug(f"icon_name is str: {icon_name}")
-            icon_name=icon_name
         else:
-            raise TypeError(f"icon_name '{icon_name}' isn't a valid type '{type(icon_name)}', "
+            raise TypeError(f"icon_name '{icon_value}' isn't a valid type '{type(icon_value)}', "
                             f"expecting str, int, Path")
 
-        if icon_name:
+        if _icon_name:
             self.layout.operator(id_name, icon=icon_name)
-        elif icon_ID:
-            self.layout.operator(id_name, icon_value=icon_ID)
+        elif _icon_ID:
+            self.layout.operator(id_name, icon_value=_icon_ID)
         else:
             self.layout.operator(id_name, icon="NONE")
+
 
     def try_menu_draw(self, context):  # self is the parent menu
         # todo check if icon exists, if not use NONE, for now dirty try except hack
@@ -102,6 +103,7 @@ def operator_wrapper(
     parent.append(menu_draw)
 
     return OperatorWrapper
+
 
 
 def menu_wrapper(parent: bpy.types.Operator, label: str) -> bpy.types.Menu:

--- a/unimenu/apps/blender.py
+++ b/unimenu/apps/blender.py
@@ -4,6 +4,8 @@
 # 3. register operators
 # 4. add operators to menu
 """
+import logging
+
 import bpy
 from typing import Union, Callable
 from unimenu.apps._abstract import MenuNodeAbstract
@@ -68,15 +70,34 @@ def operator_wrapper(
 
     # add to menu
     def menu_draw(self, context):  # self is the parent menu
+
+        icon_ID = None
+        icon_name = None
+
+        if isinstance(icon_name, int):  # use icon ID for custom icons
+            logging.debug(f"icon_name is int: {icon_name}")
+            icon_ID = icon_name
+
+        elif isinstance(icon_name, str):  # if str, can be default icon name, or a string path
+            logging.debug(f"icon_name is str: {icon_name}")
+            icon_name=icon_name
+        else:
+            raise TypeError(f"icon_name '{icon_name}' isn't a valid type '{type(icon_name)}', "
+                            f"expecting str, int, Path")
+
+        if icon_name:
+            self.layout.operator(id_name, icon=icon_name)
+        elif icon_ID:
+            self.layout.operator(id_name, icon_value=icon_ID)
+        else:
+            self.layout.operator(id_name, icon="NONE")
+
+    def try_menu_draw(self, context):  # self is the parent menu
         # todo check if icon exists, if not use NONE, for now dirty try except hack
         try:
-            if isinstance(icon_name, int):
-                # if the icon is a number it might be a custom icon
-                self.layout.operator(id_name, icon_value=icon_name)
-            else:
-                self.layout.operator(id_name, icon=icon_name)
+            return menu_draw(self, context)
         except TypeError:  # icon not found:
-            self.layout.operator(id_name, icon="NONE")
+            return self.layout.operator(id_name, icon="NONE")
 
     parent.append(menu_draw)
 

--- a/unimenu/apps/blender.py
+++ b/unimenu/apps/blender.py
@@ -40,11 +40,12 @@ def create_custom_icon(path, name: str = None):
     # icon = preview_collection["icon_name"]  # icon can be loaded by name
 
     # bpy.utils.previews.remove(preview_collection)  # delete preview to avoid warning
+    # deleting this also deletes the icon, todo how to handle this better?
     return icon_ID
 
 
 def operator_wrapper(
-    parent: bpy.types.Operator, label: str, id: str, command: Union[str, Callable], icon_name=None, tooltip=None
+    parent: bpy.types.Operator, label: str, id: str, command: Union[str, Callable], icon=None, tooltip=None
 ) -> bpy.types.Operator:
     """
     Wrap a command in a Blender operator & add it to a parent menu operator.
@@ -54,7 +55,7 @@ def operator_wrapper(
     3 add to (sub)menu (parent operator)
     """
 
-    icon_name = icon_name or "NONE"
+    icon = icon or "NONE"
     tooltip = tooltip or ""
 
     # handle name
@@ -88,38 +89,38 @@ def operator_wrapper(
     bpy.utils.register_class(OperatorWrapper)
 
     # ensure None was not accidentally passed
-    icon_value = icon_name or "NONE"
+    icon = icon or "NONE"
 
     # add to menu
     def menu_draw(self, context):  # self is the parent menu
         _icon_ID = None
         _icon_name = None
 
-        if isinstance(icon_value, int):  # use icon ID for custom icons
-            logging.debug(f"icon_name is int: {icon_value}")
-            _icon_ID = icon_value
+        if isinstance(icon, int):  # use icon ID for custom icons
+            logging.debug(f"icon is int: {icon}")
+            _icon_ID = icon
 
-        elif isinstance(icon_value, str):  # if str, can be default icon name, or a string path
-            logging.debug(f"icon_name is str: {icon_value}")
+        elif isinstance(icon, str):  # if str, can be default icon name, or a string path
+            logging.debug(f"icon is str: {icon}")
 
             # check if it's a path
-            if pathlib.Path(icon_value).exists():
-                logging.debug(f"icon_name str path exists: {icon_value}")
-                _icon_ID = create_custom_icon(icon_value)
+            if pathlib.Path(icon).exists():
+                logging.debug(f"icon str path exists: {icon}")
+                _icon_ID = create_custom_icon(icon)
 
             else:  # assume icon is a default icon name
-                logging.debug(f"icon_name str path doesn't exists: {icon_value}, assuming it's a default icon name")
-                _icon_name=icon_value
+                logging.debug(f"icon str path doesn't exists: {icon}, assuming it's a default icon name")
+                _icon_name=icon
 
-        elif isinstance(icon_name, pathlib.Path):  # use icon path for custom icons
-            _icon_ID = create_custom_icon(icon_value)
+        elif isinstance(icon, pathlib.Path):  # use icon path for custom icons
+            _icon_ID = create_custom_icon(icon)
 
         else:
-            raise TypeError(f"icon_name '{icon_value}' isn't a valid type '{type(icon_value)}', "
+            raise TypeError(f"icon '{icon}' isn't a valid type '{type(icon)}', "
                             f"expecting str, int, Path")
 
         if _icon_name:
-            self.layout.operator(id_name, icon=icon_name)
+            self.layout.operator(id_name, icon=_icon_name)
         elif _icon_ID:
             self.layout.operator(id_name, icon_value=_icon_ID)
         else:
@@ -209,7 +210,7 @@ class MenuNodeBlender(MenuNodeAbstract):
     def _setup_menu_item(self, parent_app_node=None) -> bpy.types.Operator:
         icon = self.icon or "NONE"
         tooltip = self.tooltip or ""
-        return operator_wrapper(parent=parent_app_node, label=self.label, id=self.id, command=self.run, icon_name=icon, tooltip=tooltip)
+        return operator_wrapper(parent=parent_app_node, label=self.label, id=self.id, command=self.run, icon=icon, tooltip=tooltip)
 
     def _setup_separator(self, parent_app_node=None):
         # todo return separator correctly


### PR DESCRIPTION

On Blender apart from the existing icons which can be referenced by name, they can also be custom ones created which can be referenced by id

```python
from bpy.utils import previews    
icons = previews.new()

icon = icons.load(
    name="icon_name"), 
    path="/custom/icon/path.png", 
    path_type='IMAGE'
)
icon_value = icon.icon_id
```

This changes validates the menu icon data type and properly attempts to set it by the correct argument

So when setting up the menu items, we can have a full file path as the icon key value


This is a simplified implementation that leaves the handling of the icons to the dev configuring the menus, particularly if its needed to reuse icons in other places too, but we can also include the full icon setup and check if the icon value is a file path and in such case create the icon and use it directly, open for suggestions

:) 

